### PR TITLE
Feat/upload product images

### DIFF
--- a/app/(protected)/products/[id]/page.tsx
+++ b/app/(protected)/products/[id]/page.tsx
@@ -90,13 +90,13 @@ export default function Page() {
                     <div className={"sticky top-20 space-y-4"}>
                         <Carousel>
                             <CarouselContent>
-                                {Array.from({length: 5}).map((_, index) => (
+                                {product?.images?.map((image: string, index: number) => (
                                     <CarouselItem key={index}>
                                         <div className="p-1">
                                             <Card>
                                                 <CardContent
                                                     className="flex aspect-square items-center justify-center p-6">
-                                                    <span className="text-4xl font-semibold">{index + 1}</span>
+                                                    <img src={image} alt={product.name} className="size-full object-contain" />
                                                 </CardContent>
                                             </Card>
                                         </div>

--- a/app/(protected)/products/validations/product.schema.ts
+++ b/app/(protected)/products/validations/product.schema.ts
@@ -15,7 +15,7 @@ export const ProductSchema = z.object({
     stock_quantity: z.number().min(0, "Stock must be a valid number"),
     status: z.enum(["active", "draft", "archived"]),
     category_id: z.uuid(),
-    images: z.array(z.instanceof(File)).optional(),
+    images: z.array(z.string().url()).optional(),
     variants: z
         .array(z.object({
             option: z.string(),

--- a/components/dropzone.tsx
+++ b/components/dropzone.tsx
@@ -41,9 +41,14 @@ export function Dropzone({ multiple = true, onChange, defaultValue, previewSize 
     // Track previous URLs to prevent infinite loops
     const prevUrlsRef = useRef<string>('')
 
+    // Keep onChange ref current to avoid stale closures and unnecessary effect re-runs
+    const onChangeRef = useRef(onChange)
+    onChangeRef.current = onChange
+
     // Sync uploaded files with parent component
     useEffect(() => {
-        if (!onChange) return
+        const handler = onChangeRef.current
+        if (!handler) return
 
         const uploadedUrls = uploadedFiles
             .filter((f) => f.publicUrl && !f.isUploading)
@@ -56,9 +61,9 @@ export function Dropzone({ multiple = true, onChange, defaultValue, previewSize 
         // Only call onChange if URLs actually changed
         if (prevUrlsRef.current !== currentUrlsString) {
             prevUrlsRef.current = currentUrlsString
-            onChange(multiple ? uploadedUrls : uploadedUrls[0] || '')
+            handler(multiple ? uploadedUrls : uploadedUrls[0] || '')
         }
-    }, [uploadedFiles, multiple, onChange])
+    }, [uploadedFiles, multiple])
 
     const uploadToS3 = async (file: File): Promise<string> => {
         try {
@@ -136,7 +141,7 @@ export function Dropzone({ multiple = true, onChange, defaultValue, previewSize 
                 }
             }
         },
-        [multiple, onChange]
+        [multiple]
     )
 
     const { getRootProps, getInputProps, isDragActive } = useDropzone({

--- a/types/product.d.ts
+++ b/types/product.d.ts
@@ -28,7 +28,7 @@ export interface Product {
     category: Category,
     variants?: Variant[],
     status: status,
-    images?: File[],
+    images?: string[],
     created_at: Datetime
 }
 
@@ -42,5 +42,5 @@ export interface ProductPayload {
     category_id: string,
     variants?: Variant[],
     status: status,
-    images?: File[],
+    images?: string[],
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes product data contracts from `File[]` to URL strings and adjusts form submission behavior; regressions could drop images or break validation/serialization if backend expectations differ.
> 
> **Overview**
> Adds end-to-end support for storing product images as uploaded URL strings: the product form now wires `Dropzone` into `react-hook-form` (with a ref fallback) and schema/type definitions switch `images` from `File[]` to `string[]` URLs.
> 
> Updates `Dropzone` to avoid stale `onChange` closures (ref-based handler) and updates the product detail page carousel to render actual images from `product.images` instead of placeholders.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e7d9a0a95da3abb3f871ed551d44bc3940f14949. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->